### PR TITLE
README.md，docker-build-bot.sh ，docker-start-bot.sh，以及start-bot.sh的修改

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A qq-bot named 二狗, 基于 mirai / mirai-http / Garia.
 
 ## 运行方法
 
-build bot 所需 docker 镜像: `cd script/docker-image; sh docker-build.sh`
+build bot 所需 docker 镜像: `cd script/docker-image; sh docker-build-bot.sh`
 
 运行 bot 容器并启动 bot: `sh scripts/docker-start-bot.sh`
 

--- a/scripts/docker-image/docker-build-bot.sh
+++ b/scripts/docker-image/docker-build-bot.sh
@@ -1,1 +1,5 @@
+#!/bin/sh
+if [ ! -f "mongodb-linux-x86_64-ubuntu1804-4.4.2.tgz" ]; then
+	wget http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.4.2.tgz
+fi
 sudo docker build -t ergo-bot -f Dockerfile.bot .

--- a/scripts/docker-start-bot.sh
+++ b/scripts/docker-start-bot.sh
@@ -14,4 +14,4 @@ docker run \
 #-v /mnt/1/Projects/gif-reply/data/processed/dataset/gifs:/gifs \
 # 启动mongo db
 docker exec ergo-bot-container sh -c "screen -S mongodb -md mongod --dbpath /mongo --logpath /ErGo/logs/mongod.log --fork"
-docker exec ergo-bot-container sh -c "sh /ErGo/scripts/start-bot.sh"
+docker exec ergo-bot-container sh -c "sh ${ERGO_PROJECT_DIR}/scripts/start-bot.sh"

--- a/scripts/docker-start-bot.sh
+++ b/scripts/docker-start-bot.sh
@@ -1,5 +1,8 @@
+#!/bin/bash
+
 # 推理API默认已经启动
-ERGO_PROJECT_DIR=$1
+ERGO_PROJECT_DIR=$( dirname "$(readlink -f -- "$0")" )
+ERGO_PROJECT_DIR="${ERGO_PROJECT_DIR}/.."
 echo "Using Project Dir: "$ERGO_PROJECT_DIR
 # 启动docker容器并启动bot
 docker container stop ergo-bot-container

--- a/scripts/start-bot.sh
+++ b/scripts/start-bot.sh
@@ -1,10 +1,20 @@
+#!/bin/bash
+
+ERGO_PROJECT_DIR=$( dirname "$(readlink -f -- "$0")" )
+ERGO_PROJECT_DIR="${ERGO_PROJECT_DIR}/.."
 # 此脚本应在docker容器内运行
-cd /ErGo
-mkdir logs
+cd $ERGO_PROJECT_DIR 
+if [ ! -d "${ERGO_PROJECT_DIR}/logs" ]; then
+	mkdir logs
+fi
 # 启动miral
+if [ ! -d "${ERGO_PROJECT_DIR}/mirai" ]; then
+	mkdir ${ERGO_PROJECT_DIR}/mirai
+	#TODO: 添加miraiOK_linux-amd64下载指令，或取消.gitignore中mirai文件夹以及其中不涉及个人隐藏信息的文件，GitHub上原MiraiOK仓库提供的下载地址均已失效
+fi
 cd mirai
 screen -md -S miraiOK ./miraiOK_linux-amd64
-cd /ErGo
+cd $ERGO_PROJECT_DIR
 sleep 3
 # 启动bot
 screen -md -S bot bash -c 'python3 main.py 2>&1 | tee logs/bot.log'


### PR DESCRIPTION
1.  更新README.md

将README.md中

`cd script/docker-image; sh docker-build.sh`

修改为

`cd script/docker-image; sh docker-build-bot.sh`

（不确定这项修改是否合理）

2. 优化`docker-build-bot.sh`

现在`docker-build-bot.sh`会检测路径下是否存在docker所需的`mongodb-linux-x86_64-ubuntu1804-4.4.2.tgz`文件，并在没有时从[此网址](http://downloads.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.4.2.tgz)进行下载。

3. 优化`docker-start-bot.sh`，以及`start-bot.sh`

现在以上两个shell script会自动读取project所在路径，不再将路径限制为`/ErGo`

`start-bot.sh`现在会自动检测是否存在`logs`路径以及`mirai`路径

TODO: 建议在`start-bot.sh`中添加miraiOK_linux-amd64下载指令，或取消.gitignore中mirai文件夹以及其中不涉及个人隐藏信息的文件，GitHub上[原MiraiOK仓库](https://github.com/LXY1226/miraiOK)提供的[下载地址](http://t.imlxy.net:64724/mirai/MiraiOK/miraiOK_linux-amd64)已失效